### PR TITLE
Bugfix/synchronize store access

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## Unreleased
+### Fixed
+- Synchronize store access to prevent concurrent edit errors ([#2](https://github.com/scm-manager/scm-trace-monitor-plugin/pull/2))
+
 ## [1.0.0] - 2020-11-06
 ### Added
 - Add trace monitor and configuration ([#1](https://github.com/scm-manager/scm-trace-monitor-plugin/pull/1))

--- a/docs/en/trace-monitor/index.md
+++ b/docs/en/trace-monitor/index.md
@@ -3,7 +3,6 @@ title: Trace Monitor
 subtitle: Latest requests
 ---
 
-After the installation of the script plugin there is a "Scripts" entry in the navigation menu of the administration area of SCM-Manager.
 The Trace Monitor page shows a table of the recent requests. This table is sortable and filterable.
 
 ![Trace Monitor](assets/trace-monitor.png)

--- a/src/main/java/com/cloudogu/scm/tracemonitor/TraceStore.java
+++ b/src/main/java/com/cloudogu/scm/tracemonitor/TraceStore.java
@@ -24,14 +24,17 @@
 package com.cloudogu.scm.tracemonitor;
 
 import com.cloudogu.scm.tracemonitor.config.GlobalConfigStore;
+import com.google.common.annotations.VisibleForTesting;
+import com.google.common.util.concurrent.Striped;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 import org.apache.shiro.SecurityUtils;
-import sonia.scm.store.ConfigurationEntryStoreFactory;
 import sonia.scm.store.DataStore;
+import sonia.scm.store.DataStoreFactory;
 import sonia.scm.trace.SpanContext;
 
 import javax.inject.Inject;
+import javax.inject.Singleton;
 import javax.xml.bind.annotation.XmlAccessType;
 import javax.xml.bind.annotation.XmlAccessorType;
 import javax.xml.bind.annotation.XmlElement;
@@ -39,45 +42,62 @@ import javax.xml.bind.annotation.XmlRootElement;
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.List;
-import java.util.stream.Collectors;
+import java.util.concurrent.locks.Lock;
+import java.util.concurrent.locks.ReadWriteLock;
+import java.util.function.Supplier;
 
+@Singleton
 public class TraceStore {
 
   private static final String STORE_NAME = "trace-monitor";
-  private final ConfigurationEntryStoreFactory storeFactory;
+  private final DataStoreFactory storeFactory;
   private final GlobalConfigStore globalConfigStore;
+  private final Striped<ReadWriteLock> locks = Striped.readWriteLock(10);
 
   @Inject
-  public TraceStore(ConfigurationEntryStoreFactory storeFactory, GlobalConfigStore globalConfigStore) {
+  public TraceStore(DataStoreFactory storeFactory, GlobalConfigStore globalConfigStore) {
     this.storeFactory = storeFactory;
     this.globalConfigStore = globalConfigStore;
   }
 
   public Collection<SpanContext> getAll() {
     SecurityUtils.getSubject().checkPermission("traceMonitor:read");
-    DataStore<StoreEntry> store = createStore();
     List<SpanContext> spans = new ArrayList<>();
-    store.getAll().values().forEach(entry -> spans.addAll(entry.getSpans()));
+    doSynchronized("", false, () -> {
+      createStore()
+        .getAll()
+        .values()
+        .forEach(entry -> spans.addAll(entry.getSpans()));
+      return null;
+    });
     return spans;
   }
 
   public Collection<SpanContext> get(String kind) {
-    return getAll().stream()
-      .filter(span -> kind.equalsIgnoreCase(span.getKind()))
-      .collect(Collectors.toList());
+    SecurityUtils.getSubject().checkPermission("traceMonitor:read");
+
+    final ArrayList<SpanContext> spans = new ArrayList<>();
+    doSynchronized(kind, false, () -> {
+      spans.addAll(createStore().get(kind).getSpans());
+      return null;
+    });
+
+    return spans;
   }
 
-  void add(SpanContext spanContext) {
-    DataStore<StoreEntry> store = createStore();
-    StoreEntry storeEntry = store.get(spanContext.getKind());
-    int configuredStoreSize = globalConfigStore.get().getStoreSize();
-    if (storeEntry == null) {
-      storeEntry = new StoreEntry(configuredStoreSize);
-    }
-    storeEntry = resizeStoreEntryMaxSize(storeEntry, configuredStoreSize);
-    storeEntry.getSpans().add(spanContext);
-    store.put(spanContext.getKind(), storeEntry);
-
+  synchronized void add(SpanContext spanContext) {
+    doSynchronized(spanContext.getKind(), true, () -> {
+      DataStore<StoreEntry> store = createStore();
+      StoreEntry storeEntry = store.get(spanContext.getKind());
+      int configuredStoreSize = globalConfigStore.get().getStoreSize();
+      if (storeEntry == null) {
+        storeEntry = new StoreEntry(configuredStoreSize);
+      }
+      storeEntry = resizeStoreEntryMaxSize(storeEntry, configuredStoreSize);
+      storeEntry.getSpans().add(spanContext);
+      store.put(spanContext.getKind(), storeEntry);
+      return null;
+    });
   }
 
   private StoreEntry resizeStoreEntryMaxSize(StoreEntry storeEntry, int configuredStoreSize) {
@@ -89,6 +109,17 @@ public class TraceStore {
     return storeEntry;
   }
 
+  private <T> T doSynchronized(String category, boolean write, Supplier<T> callback) {
+    final ReadWriteLock lockFactory = locks.get(category);
+    Lock lock = write ? lockFactory.writeLock() : lockFactory.readLock();
+    lock.lock();
+    try {
+      return callback.get();
+    } finally {
+      lock.unlock();
+    }
+  }
+
   private DataStore<StoreEntry> createStore() {
     return storeFactory.withType(StoreEntry.class).withName(STORE_NAME).build();
   }
@@ -97,11 +128,12 @@ public class TraceStore {
   @XmlAccessorType(XmlAccessType.FIELD)
   @Getter
   @NoArgsConstructor
-  static class StoreEntry {
+  public static class StoreEntry {
     @XmlElement(name = "request")
     private EvictingQueue<SpanContext> spans;
 
-    StoreEntry(int storeSize) {
+    @VisibleForTesting
+    public StoreEntry(int storeSize) {
       spans = EvictingQueue.create(storeSize);
     }
   }

--- a/src/main/java/com/cloudogu/scm/tracemonitor/update/TraceMonitorStoreUpdateStep.java
+++ b/src/main/java/com/cloudogu/scm/tracemonitor/update/TraceMonitorStoreUpdateStep.java
@@ -1,0 +1,79 @@
+/*
+ * MIT License
+ *
+ * Copyright (c) 2020-present Cloudogu GmbH and Contributors
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+package com.cloudogu.scm.tracemonitor.update;
+
+import com.cloudogu.scm.tracemonitor.TraceStore;
+import sonia.scm.migration.UpdateStep;
+import sonia.scm.plugin.Extension;
+import sonia.scm.store.ConfigurationEntryStore;
+import sonia.scm.store.ConfigurationEntryStoreFactory;
+import sonia.scm.store.DataStore;
+import sonia.scm.store.DataStoreFactory;
+import sonia.scm.version.Version;
+
+import javax.inject.Inject;
+import java.util.Map;
+
+import static sonia.scm.version.Version.parse;
+
+@Extension
+public class TraceMonitorStoreUpdateStep implements UpdateStep {
+
+  private static final String STORE_NAME = "trace-monitor";
+  private final DataStoreFactory dataStoreFactory;
+  private final ConfigurationEntryStoreFactory configurationEntryStoreFactory;
+
+  @Inject
+  public TraceMonitorStoreUpdateStep(DataStoreFactory dataStoreFactory, ConfigurationEntryStoreFactory configurationEntryStoreFactory) {
+    this.dataStoreFactory = dataStoreFactory;
+    this.configurationEntryStoreFactory = configurationEntryStoreFactory;
+  }
+
+  @Override
+  public void doUpdate() {
+    ConfigurationEntryStore<TraceStore.StoreEntry> configurationEntryStore = configurationEntryStoreFactory
+      .withType(TraceStore.StoreEntry.class)
+      .withName(STORE_NAME)
+      .build();
+    Map<String, TraceStore.StoreEntry> spans = configurationEntryStore.getAll();
+
+    DataStore<TraceStore.StoreEntry> dataStore = dataStoreFactory
+      .withType(TraceStore.StoreEntry.class)
+      .withName(STORE_NAME)
+      .build();
+
+    spans.forEach(dataStore::put);
+    configurationEntryStore.clear();
+  }
+
+  @Override
+  public Version getTargetVersion() {
+    return parse("2.9.0");
+  }
+
+  @Override
+  public String getAffectedDataType() {
+    return "sonia.scm.plugin.tracemonitor";
+  }
+}

--- a/src/test/java/com/cloudogu/scm/tracemonitor/TraceExporterTest.java
+++ b/src/test/java/com/cloudogu/scm/tracemonitor/TraceExporterTest.java
@@ -35,7 +35,8 @@ import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 import sonia.scm.event.ScmEventBus;
-import sonia.scm.store.InMemoryConfigurationEntryStoreFactory;
+import sonia.scm.store.InMemoryDataStore;
+import sonia.scm.store.InMemoryDataStoreFactory;
 import sonia.scm.trace.SpanContext;
 
 import java.time.Instant;
@@ -61,7 +62,8 @@ class TraceExporterTest {
   @BeforeEach
   void initStore() {
     ThreadContext.bind(subject);
-    InMemoryConfigurationEntryStoreFactory factory = new InMemoryConfigurationEntryStoreFactory();
+    InMemoryDataStore<TraceStore.StoreEntry> dataStore = new InMemoryDataStore<>();
+    InMemoryDataStoreFactory factory = new InMemoryDataStoreFactory(dataStore);
     store = new TraceStore(factory, globalConfigStore);
     traceExporter = new TraceExporter(store, eventBus);
   }

--- a/src/test/java/com/cloudogu/scm/tracemonitor/TraceStoreTest.java
+++ b/src/test/java/com/cloudogu/scm/tracemonitor/TraceStoreTest.java
@@ -35,7 +35,8 @@ import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
-import sonia.scm.store.InMemoryConfigurationEntryStoreFactory;
+import sonia.scm.store.InMemoryDataStore;
+import sonia.scm.store.InMemoryDataStoreFactory;
 import sonia.scm.trace.SpanContext;
 
 import java.time.Instant;
@@ -59,7 +60,8 @@ class TraceStoreTest {
   @BeforeEach
   void initStore() {
     ThreadContext.bind(subject);
-    InMemoryConfigurationEntryStoreFactory factory = new InMemoryConfigurationEntryStoreFactory();
+    InMemoryDataStore<TraceStore.StoreEntry> dataStore = new InMemoryDataStore<>();
+    InMemoryDataStoreFactory factory = new InMemoryDataStoreFactory(dataStore);
     store = new TraceStore(factory, globalConfigStore);
   }
 

--- a/src/test/java/com/cloudogu/scm/tracemonitor/update/TraceMonitorStoreUpdateStepTest.java
+++ b/src/test/java/com/cloudogu/scm/tracemonitor/update/TraceMonitorStoreUpdateStepTest.java
@@ -1,0 +1,88 @@
+/*
+ * MIT License
+ *
+ * Copyright (c) 2020-present Cloudogu GmbH and Contributors
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+package com.cloudogu.scm.tracemonitor.update;
+
+import com.cloudogu.scm.tracemonitor.TraceStore;
+import com.google.common.collect.ImmutableMap;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Answers;
+import org.mockito.ArgumentCaptor;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import sonia.scm.store.ConfigurationEntryStore;
+import sonia.scm.store.ConfigurationEntryStoreFactory;
+import sonia.scm.store.DataStore;
+import sonia.scm.store.DataStoreFactory;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+@ExtendWith(MockitoExtension.class)
+class TraceMonitorStoreUpdateStepTest {
+
+  @Mock(answer = Answers.RETURNS_DEEP_STUBS)
+  private ConfigurationEntryStoreFactory configurationEntryStoreFactory;
+  @Mock(answer = Answers.RETURNS_DEEP_STUBS)
+  private DataStoreFactory dataStoreFactory;
+  @InjectMocks
+  private TraceMonitorStoreUpdateStep updateStep;
+
+  @Test
+  void shouldMigrateConfigStoreToDataStore() {
+    ConfigurationEntryStore<TraceStore.StoreEntry> entryStore = mock(ConfigurationEntryStore.class);
+    DataStore<TraceStore.StoreEntry> dataStore = mock(DataStore.class);
+    when(entryStore.getAll()).thenReturn(ImmutableMap.of("http", new TraceStore.StoreEntry(2), "Release Feed", new TraceStore.StoreEntry(12)));
+    when(dataStoreFactory.withType(TraceStore.StoreEntry.class).withName("trace-monitor").build()).thenReturn(dataStore);
+    when(configurationEntryStoreFactory.withType(TraceStore.StoreEntry.class).withName("trace-monitor").build()).thenReturn(entryStore);
+
+    updateStep.doUpdate();
+
+    ArgumentCaptor<TraceStore.StoreEntry> captor = ArgumentCaptor.forClass(TraceStore.StoreEntry.class);
+
+    verify(dataStore).put(eq("http"), captor.capture());
+    verify(dataStore).put(eq("Release Feed"), captor.capture());
+    assertThat(captor.getAllValues().get(0).getSpans()).isEmpty();
+    assertThat(captor.getAllValues().get(1).getSpans()).isEmpty();
+  }
+
+  @Test
+  void shouldDoNothingIfNoEntriesExist() {
+    ConfigurationEntryStore<TraceStore.StoreEntry> entryStore = mock(ConfigurationEntryStore.class);
+    DataStore<TraceStore.StoreEntry> dataStore = mock(DataStore.class);
+    when(dataStoreFactory.withType(TraceStore.StoreEntry.class).withName("trace-monitor").build()).thenReturn(dataStore);
+    when(configurationEntryStoreFactory.withType(TraceStore.StoreEntry.class).withName("trace-monitor").build()).thenReturn(entryStore);
+
+    updateStep.doUpdate();
+
+    verify(dataStore, never()).put(anyString(), any());
+  }
+}


### PR DESCRIPTION
## Proposed changes
Synchronize store access

Store different categories in own file each and synchronize access to prevent concurrent edit errors. Also add migration step for stored data from old store to the new one.

### Your checklist for this pull request

- [x] PR is well described and the description can be used as commit message on squash
- [x] Related issues linked to PR if existing and labels set
- [x] Target branch is not master (in most cases develop should bet the target of choice) 
- [x] Code does not conflict with target branch
- [x] New code is covered with unit tests
- [x] CHANGELOG.md updated
- [x] Definition of Done's fulfilled: [DoD](https://github.com/scm-manager/scm-manager/blob/develop/docs/en/development/definition-of-done.md) // [UI DoD](https://github.com/scm-manager/scm-manager/blob/develop/docs/en/development/ui-dod.md)
- [ ] Documentation updated (only necessary for new features or changed behaviour)

### Checklist for branch merge request (not required for forks)

- [ ] Branch is green/blue on [Jenkins](https://oss.cloudogu.com/jenkins/)
- [ ] Quality Gate passed on [SonarQube](https://sonarcloud.io/organizations/scm-manager/projects)
